### PR TITLE
[#743] Allow css class options for link_to

### DIFF
--- a/lib/locomotive/liquid/tags/link_to.rb
+++ b/lib/locomotive/liquid/tags/link_to.rb
@@ -15,7 +15,12 @@ module Locomotive
               label = super.html_safe
             end
 
-            link_to label, path
+            if @options['class']
+              css_classes = @options['class'].gsub("'", '')
+              css_classes = css_classes.split(' ')
+            end
+
+            link_to label, path, {:class => css_classes}
           end
         end
 

--- a/spec/lib/locomotive/liquid/tags/link_to_spec.rb
+++ b/spec/lib/locomotive/liquid/tags/link_to_spec.rb
@@ -54,6 +54,22 @@ describe Locomotive::Liquid::Tags::LinkTo do
 
   end
 
+  describe 'with a custom css class' do
+    let(:page)      { create_page(site, 'Hello world', 'my-page') }
+    let(:template)  { "{% link_to my-page, class: 'custom-class' %}" }
+    before(:each)   { page }
+
+    it { should == %{<a href="/hello-world" class="custom-class">Hello world</a>} }
+  end
+
+  describe 'with multiple css classes' do
+    let(:page)      { create_page(site, 'Hello world', 'my-page') }
+    let(:template)  { "{% link_to my-page, class: 'custom-class-one custom-class-two' %}" }
+    before(:each)   { page }
+
+    it { should == %{<a href="/hello-world" class="custom-class-one custom-class-two">Hello world</a>} }
+  end
+
   describe 'templatized page' do
 
     let(:parent_page)   { create_page(site, 'List of projects') }


### PR DESCRIPTION
Updates `link_to` to allow `class` option for css classes.
