### PR TITLE
Remove Admin button inline styling

### DIFF
--- a/lib/locomotive/middlewares/inline_editor.rb
+++ b/lib/locomotive/middlewares/inline_editor.rb
@@ -18,13 +18,7 @@ module Locomotive
         [].tap do |parts|
           response.each do |part|
             parts << part.to_s.gsub('</body>', %(
-             <a  href="#{File.join(response.request.path, '/_admin')}"
-                 onmouseout="this.style.backgroundPosition='0px 0px'"
-                 onmouseover="this.style.backgroundPosition='0px -45px'"
-                 onmousedown="this.style.backgroundPosition='0px -90px'"
-                 onmouseup="this.style.backgroundPosition='0px 0px'"
-                 style="display: block;z-index: 1031;position: fixed;top: 10px; right: 10px;width: 48px; height: 45px;text-indent:-9999px;text-decoration:none;background: transparent url\('/assets/locomotive/icons/start.png'\) no-repeat 0 0;">
-             Admin</a>
+             <a  href="#{File.join(response.request.path, '/_admin')}" id="locomotive-inline-admin-button">Admin</a>
              </body>
              ))
           end


### PR DESCRIPTION
@justinhillsjohnson 

The admin button looked real bad on my engine so I removed the inline styling and it can now be styled in the app's theme_assets via the selector `#locomotive-inline-admin-button`
