### PR TITLE
Make API Key double-clickable for ease of copying in backend

### DIFF
--- a/app/assets/stylesheets/locomotive/backoffice/formtastic_changes.css.scss
+++ b/app/assets/stylesheets/locomotive/backoffice/formtastic_changes.css.scss
@@ -494,6 +494,13 @@ form.formtastic {
             @include blue-button;
             margin-left: 10px;
           }
+          .api-key-display {
+            padding: .25rem;
+            vertical-align: top;
+            font-size: 16px;
+            height: 1rem;
+            font-family: Monaco, monospace;
+          }
         }
 
         &.subdomain {

--- a/app/inputs/locomotive/api_key_input.rb
+++ b/app/inputs/locomotive/api_key_input.rb
@@ -19,7 +19,7 @@ module Locomotive
 
     def api_key_html
       api_key = self.object.api_key || I18n.t('locomotive.api_key.none')
-      template.content_tag :code, api_key
+      template.content_tag :textarea, api_key, :readonly => 'readonly', :class => 'api-key-display'
     end
 
     def regenerate_button


### PR DESCRIPTION
@justinhillsjohnson 

This just wraps the API Key value in the my_account view of the backend in a `textarea` with `readonly` so we can double-click to select it without selecting the label text as well.
